### PR TITLE
MOB-2814: iOS - Emojis entities are not send

### DIFF
--- a/NSStringEmojize/NSString+Emojize.m
+++ b/NSStringEmojize/NSString+Emojize.m
@@ -57,7 +57,7 @@ BOOL NSRangeIntersectsRange(NSRange range1, NSRange range2) {
                 NSString *code = [text substringWithRange:range];
                 NSString *unicode = self.emojiAliases[code];
                 if (unicode && !rangesIntersects) {
-                    resultText = [resultText stringByReplacingOccurrencesOfString:code withString:unicode];
+                    resultText = [resultText stringByReplacingCharactersInRange:range withString:unicode];
                     [matchingRanges addObject:[NSValue valueWithRange: range]];
                     //range.length with be the number of characters reduced
                     range.length -= [unicode length];


### PR DESCRIPTION
## Description
https://perzoinc.atlassian.net/browse/MOB-2814

## Code:

#### Problem:
Some aliases were not being replaced by emojis (i.e., `:warning:` --> `⚠️`)
 
#### Fix:
Fix alias-to-emoji conversion, using `[NSString stringByReplacingCharactersInRange:withString:]`

#### Unit Tests
None

## Others:

#### Related PRs
https://github.com/SymphonyOSF/SIOS-Client-App/pull/4415