### PR TITLE
MOB-2814: iOS - Emojis entities are not send

### DIFF
--- a/NSStringEmojize/NSString+Emojize.m
+++ b/NSStringEmojize/NSString+Emojize.m
@@ -56,10 +56,10 @@ BOOL NSRangeIntersectsRange(NSRange range1, NSRange range2) {
                 NSString *unicode = self.emojiAliases[code];
                 if (unicode && !rangesIntersects) {
                     resultText = [resultText stringByReplacingCharactersInRange:range withString:unicode];
-                    [matchingRanges addObject:[NSValue valueWithRange: range]];
+                    [matchingRanges insertObject:[NSValue valueWithRange: range] atIndex:0];
                     //range.length with be the number of characters reduced
                     range.length -= [unicode length];
-                    [matchingLengthChanges addObject:[NSValue valueWithRange: range]];
+                    [matchingLengthChanges insertObject:[NSValue valueWithRange: range] atIndex:0];
                 }
             }
         }


### PR DESCRIPTION
## Description
https://perzoinc.atlassian.net/browse/MOB-2814

## Code:

#### Problem:
The last PR introduced an issue by inverting the order the emoji ranges were detected
 
#### Fix:
Keep emoji ranges ordered

#### Unit Tests
None

## Others:

#### Related PRs
https://github.com/SymphonyOSF/SIOS-Client-App/pull/4415
https://github.com/SymphonyOSF/NSStringEmojize/pull/3
https://github.com/SymphonyOSF/NSStringEmojize/pull/4